### PR TITLE
Update manifest schema for ce create command

### DIFF
--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -376,6 +376,11 @@
                                     "description": "Id of the command.",
                                     "maxLength": 64
                                 },
+                                "type": {
+                                    "type": "string",
+                                    "enum": [ "Query", "Action" ],
+                                    "description": "Type of the command"
+                                },
                                 "title": {
                                     "type": "string",
                                     "description": "Title of the command.",
@@ -391,6 +396,11 @@
                                     "description": "A boolean value that indicates if the command should be run once initially with no parameter.",
                                     "default": false
                                 },
+                                "fetchTask": {
+                                    "type": "boolean",
+                                    "description": "A boolean value that indicates if it should fetch task module dynamically",
+                                    "default": false
+                                },
                                 "parameters": {
                                     "type": "array",
                                     "maxItems": 5,
@@ -403,6 +413,11 @@
                                                 "type": "string",
                                                 "description": "Name of the parameter.",
                                                 "maxLength": 64
+                                            },
+                                            "inputType": {
+                                                "type": "string",
+                                                "enum": [ "Text", "Textarea", "Number", "Date", "Time", "Toggle", "Choiceset" ],
+                                                "description": "Type of the parameter"
                                             },
                                             "title": {
                                                 "type": "string",


### PR DESCRIPTION
change the manifest schema for inputExtensions
1. add field "type" for commands, it can be "Query" or "Action"
2. add field "fetchTask" for commands whose type is boolean
3. add filed "inputType" for parameters of commands, it can be anyone of [ "Text", "Textarea", "Number", "Date", "Time", "Toggle", "Choiceset" ]